### PR TITLE
feat: 打开HiveDialect limit comma配置

### DIFF
--- a/src/dialect/hive.rs
+++ b/src/dialect/hive.rs
@@ -71,4 +71,9 @@ impl Dialect for HiveDialect {
     fn supports_group_by_with_modifier(&self) -> bool {
         true
     }
+
+    /// Does the dialect support parsing `LIMIT 1, 2` as `LIMIT 2 OFFSET 1`?
+    fn supports_limit_comma(&self) -> bool {
+        true
+    }
 }

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -548,6 +548,13 @@ fn parse_use() {
 }
 
 #[test]
+fn hive_limit_offset() {
+    let sql = "SELECT * FROM foo LIMIT 100, 200";
+    let expected = "SELECT * FROM foo LIMIT 200 OFFSET 100";
+    println!("{}", hive().one_statement_parses_to(sql, expected));
+}
+
+#[test]
 fn test_tample_sample() {
     hive().verified_stmt("SELECT * FROM source TABLESAMPLE (BUCKET 3 OUT OF 32 ON rand()) AS s");
     hive().verified_stmt("SELECT * FROM source TABLESAMPLE (BUCKET 3 OUT OF 16 ON id)");


### PR DESCRIPTION
支持limit 10,10000这种简写语法